### PR TITLE
Ballista's only target players when pvp is enabled

### DIFF
--- a/Helper.cs
+++ b/Helper.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace ImFRIENDLY
+{
+    public class Helper
+    {
+        public static Character FindClosestCreature(Transform me, Vector3 eyePoint, float hearRange, float viewRange, float viewAngle, bool alerted, bool mistVision)
+        {
+            List<Character> allCharacters = Character.GetAllCharacters();
+            Character character = null;
+            float num = 99999f;
+            foreach (Character item in allCharacters)
+            {
+                if (item.IsDead() || item.IsTamed() || (item.IsPlayer() && !item.IsPVPEnabled()))
+                {
+                    continue;
+                }
+
+                BaseAI baseAI = item.GetBaseAI();
+                if ((!(baseAI != null) || !baseAI.IsSleeping()) && BaseAI.CanSenseTarget(me, eyePoint, hearRange, viewRange, viewAngle, alerted, mistVision, item))
+                {
+                    float num2 = Vector3.Distance(item.transform.position, me.position);
+                    if (num2 < num || character == null)
+                    {
+                        character = item;
+                        num = num2;
+                    }
+                }
+            }
+
+            return character;
+        }
+    }
+}

--- a/ImFRIENDLY.csproj
+++ b/ImFRIENDLY.csproj
@@ -89,6 +89,7 @@
         </Reference>
     </ItemGroup>
     <ItemGroup>
+        <Compile Include="Helper.cs" />
         <Compile Include="Plugin.cs" />
         <Compile Include="Properties\AssemblyInfo.cs" />
     </ItemGroup>

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -31,37 +31,106 @@ namespace ImFRIENDLY
     [HarmonyPatch(typeof(Turret), nameof(Turret.UpdateTarget))]
     static class TurretUpdateTargetPatch
     {
-        static void Prefix(Turret __instance)
+        static bool Prefix(Turret __instance, float dt)
         {
-            ImFRIENDLYDAMMIT(__instance);
+            ImFRIENDLYDAMMIT(__instance, dt);
+            // By returning false, we skip other Prefix methods as well as the original UpdateTarget method.
+            return false;
         }
 
-        static void Postfix(Turret __instance)
+        private static void ImFRIENDLYDAMMIT(Turret instance, float dt)
         {
-            ImFRIENDLYDAMMIT(__instance);
-        }
-
-        private static void ImFRIENDLYDAMMIT(Turret __instance)
-        {
-            if (!__instance.m_nview.IsValid())
-                return;
-            if (__instance.m_target == null) return;
-
-
-            if (!__instance.HasAmmo())
-            {
-                if (!__instance.m_haveTarget)
-                    return;
-            }
-            if (__instance.m_target.IsTamed())
-                __instance.m_target = null;
-            if (!__instance.m_target.IsPlayer() && __instance.m_target != Player.m_localPlayer) return;
-            if (__instance.m_target.IsPVPEnabled())
+            // This code is coppied from Turret.UpdateTarget, the only modification is where we get the closest creature
+            // which uses our helper method instead of the original BaseAI.FindClosestCreature
+            if (!instance.m_nview.IsValid())
             {
                 return;
             }
+            if (!instance.HasAmmo())
+            {
+                if (instance.m_haveTarget)
+                {
+                    instance.m_nview.InvokeRPC(ZNetView.Everybody, "RPC_SetTarget", ZDOID.None);
+                }
+                return;
+            }
+            instance.m_updateTargetTimer -= dt;
+            if (instance.m_updateTargetTimer <= 0f)
+            {
+                instance.m_updateTargetTimer = (Character.IsCharacterInRange(instance.transform.position, 40f) ? instance.m_updateTargetIntervalNear : instance.m_updateTargetIntervalFar);
+                Character character = Helper.FindClosestCreature(instance.transform, instance.m_eye.transform.position, 0f, instance.m_viewDistance, instance.m_horizontalAngle, alerted: false, mistVision: false);
+                if (character != instance.m_target)
+                {
+                    if ((bool)character)
+                    {
+                        instance.m_newTargetEffect.Create(instance.transform.position, instance.transform.rotation);
+                    }
+                    else
+                    {
+                        instance.m_lostTargetEffect.Create(instance.transform.position, instance.transform.rotation);
+                    }
+                    instance.m_nview.InvokeRPC(ZNetView.Everybody, "RPC_SetTarget", character ? character.GetZDOID() : ZDOID.None);
+                }
+            }
+            if (instance.m_haveTarget && (!instance.m_target || instance.m_target.IsDead()))
+            {
+                ZLog.Log("Target is gone");
+                instance.m_nview.InvokeRPC(ZNetView.Everybody, "RPC_SetTarget", ZDOID.None);
+                instance.m_lostTargetEffect.Create(instance.transform.position, instance.transform.rotation);
+            }
+        }
+    }
 
-            __instance.m_target = null;
+    [HarmonyPatch(typeof(Turret), nameof(Turret.ShootProjectile))]
+    static class TurretShootProjectilePatch
+    {
+        static bool Prefix(Turret __instance)
+        {
+            ImFRIENDLYDAMMIT(__instance);
+            return false;
+        }
+
+        private static void ImFRIENDLYDAMMIT(Turret instance)
+        {
+            // This code is coppied from Turret.ShootProjectile, the only modification is the setup call for the
+            // projectile to set the local player as the owner that way the projectile doesn't do friendly damage
+            Transform transform = instance.m_eye.transform;
+            instance.m_shootEffect.Create(transform.position, transform.rotation);
+            instance.m_nview.GetZDO().Set("lastAttack", (float)ZNet.instance.GetTimeSeconds());
+            instance.m_lastAmmo = instance.GetAmmoItem();
+            int @int = instance.m_nview.GetZDO().GetInt("ammo");
+            int num = Mathf.Min(1, (instance.m_maxAmmo == 0) ? instance.m_lastAmmo.m_shared.m_attack.m_projectiles : Mathf.Min(@int, instance.m_lastAmmo.m_shared.m_attack.m_projectiles));
+            if (instance.m_maxAmmo > 0)
+            {
+                instance.m_nview.GetZDO().Set("ammo", @int - num);
+            }
+            ZLog.Log($"Turret '{instance.name}' is shooting {num} projectiles, ammo: {@int}/{instance.m_maxAmmo}");
+            for (int i = 0; i < num; i++)
+            {
+                Vector3 forward = transform.forward;
+                Vector3 axis = Vector3.Cross(forward, Vector3.up);
+                float projectileAccuracy = instance.m_lastAmmo.m_shared.m_attack.m_projectileAccuracy;
+                Quaternion quaternion = Quaternion.AngleAxis(Random.Range(0f - projectileAccuracy, projectileAccuracy), Vector3.up);
+                forward = Quaternion.AngleAxis(Random.Range(0f - projectileAccuracy, projectileAccuracy), axis) * forward;
+                forward = quaternion * forward;
+                instance.m_lastProjectile = Object.Instantiate(instance.m_lastAmmo.m_shared.m_attack.m_attackProjectile, transform.position, transform.rotation);
+                HitData hitData = new HitData();
+                hitData.m_toolTier = instance.m_lastAmmo.m_shared.m_toolTier;
+                hitData.m_pushForce = instance.m_lastAmmo.m_shared.m_attackForce;
+                hitData.m_backstabBonus = instance.m_lastAmmo.m_shared.m_backstabBonus;
+                hitData.m_staggerMultiplier = instance.m_lastAmmo.m_shared.m_attack.m_staggerMultiplier;
+                hitData.m_damage.Add(instance.m_lastAmmo.GetDamage());
+                hitData.m_statusEffect = (instance.m_lastAmmo.m_shared.m_attackStatusEffect ? instance.m_lastAmmo.m_shared.m_attackStatusEffect.name : "");
+                hitData.m_blockable = instance.m_lastAmmo.m_shared.m_blockable;
+                hitData.m_dodgeable = instance.m_lastAmmo.m_shared.m_dodgeable;
+                hitData.m_skill = instance.m_lastAmmo.m_shared.m_skillType;
+                if (instance.m_lastAmmo.m_shared.m_attackStatusEffect != null)
+                {
+                    hitData.m_statusEffect = instance.m_lastAmmo.m_shared.m_attackStatusEffect.name;
+                }
+                instance.m_lastProjectile.GetComponent<IProjectile>()?.Setup(Player.m_localPlayer.IsPVPEnabled() ? null : Player.m_localPlayer, forward * instance.m_lastAmmo.m_shared.m_attack.m_projectileVel, instance.m_hitNoise, hitData, null, instance.m_lastAmmo);
+            }
+            instance.m_warmup = -100f;
         }
     }
 }


### PR DESCRIPTION
Ballistas can target creatures behind the player when pvp is turned off. The player set as the owner for the projectile when pvp is turned off so that the projectile can't damage the player.